### PR TITLE
Fix typo in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
 		
 		<div class="jumbotron">
 			<div class="container">
-				<h1>Wecome to ISSOtm's website</h1>
+				<h1>Welcome to ISSOtm's website</h1>
 				<p>
 					Hey ! I'm Eldred, I'm 19 (subject to change) and I love programming (subject to never change).
 					<br/>


### PR DESCRIPTION
Fix a glaring typo in the header: "Wecome" -> "Welcome"